### PR TITLE
Fix process-compose configuration

### DIFF
--- a/examples/hello-http/.process-compose.yaml
+++ b/examples/hello-http/.process-compose.yaml
@@ -3,14 +3,10 @@ processes:
     description: The Enclave Application
     command: go run ./enclave/main.go --config ./configs/notee-config.yaml
     ready_log_line: "Enclave server started"
-    availability:
-      exit_on_end: true
   enclave-proxy:
     description: The Enclave-Proxy Application
     command: go run ./enclave-proxy/main.go --config ./configs/notee-config.yaml
     ready_log_line: "Proxy server started"
-    availability:
-      exit_on_end: true
   nonclave:
     description: The Non-Enclave Application
     command: go run ./nonclave/main.go

--- a/examples/hello-http/Makefile
+++ b/examples/hello-http/Makefile
@@ -11,8 +11,7 @@ SHELL := bash
 ################################################################################
 .PHONY: notee-hello-http
 notee-hello-http:
-	@-make --no-print-directory notee-start-processes
-	@-make --no-print-directory notee-stop-processes
+	@make --no-print-directory notee-start-processes
 
 # Make sure your process-compose port does not conflict with
 # the ports used by enclave, proxy, or nonclave processes
@@ -20,11 +19,11 @@ notee-hello-http:
 PROCESS_COMPOSE_PORT=8083
 .PHONY: notee-start-processes
 notee-start-processes:
-	@-process-compose up --tui=false --port=${PROCESS_COMPOSE_PORT} -f .process-compose.yaml 2> /dev/null
+	@process-compose up --tui=false --port=${PROCESS_COMPOSE_PORT} -f .process-compose.yaml 2> /dev/null
 
 .PHONY: notee-stop-processes
 notee-stop-processes:
-	@-process-compose down --port=${PROCESS_COMPOSE_PORT} 2> /dev/null
+	@process-compose down --port=${PROCESS_COMPOSE_PORT} 2> /dev/null
 
 ################################################################################
 # Build Binaries

--- a/examples/hello-world/.process-compose.yaml
+++ b/examples/hello-world/.process-compose.yaml
@@ -3,14 +3,10 @@ processes:
     description: The Enclave Application
     command: go run ./enclave/main.go --config ./configs/notee-config.yaml
     ready_log_line: "waiting to receive"
-    availability:
-      exit_on_end: true
   enclave-proxy:
     description: The Enclave-Proxy Application
     command: go run ./enclave-proxy/main.go --config ./configs/notee-config.yaml
     ready_log_line: "HTTP server started"
-    availability:
-      exit_on_end: true
   nonclave:
     description: The Non-Enclave Application
     command: go run ./nonclave/main.go

--- a/examples/hello-world/Makefile
+++ b/examples/hello-world/Makefile
@@ -11,8 +11,7 @@ SHELL := bash
 ################################################################################
 .PHONY: notee-hello-world
 notee-hello-world:
-	@-make --no-print-directory notee-start-processes
-	@-make --no-print-directory notee-stop-processes
+	@make --no-print-directory notee-start-processes
 
 # Make sure your process-compose port does not conflict with
 # the ports used by enclave, proxy, or nonclave processes
@@ -20,11 +19,11 @@ notee-hello-world:
 PROCESS_COMPOSE_PORT=8083
 .PHONY: notee-start-processes
 notee-start-processes:
-	@-process-compose up --tui=false --port=${PROCESS_COMPOSE_PORT} -f .process-compose.yaml 2> /dev/null
+	@process-compose up --tui=false --port=${PROCESS_COMPOSE_PORT} -f .process-compose.yaml 2> /dev/null
 
 .PHONY: notee-stop-processes
 notee-stop-processes:
-	@-process-compose down --port=${PROCESS_COMPOSE_PORT} 2> /dev/null
+	@process-compose down --port=${PROCESS_COMPOSE_PORT} 2> /dev/null
 
 ################################################################################
 # Build Binaries


### PR DESCRIPTION
The `availability.exit_on_end` should only be applied to the process that you want to use to trigger a global shutdown (in this case the nonclave process). Otherwise, putting it on all processes, causes `process-compose` to exit non-zero when shutting down