### PR TITLE
AWS and examples readmes

### DIFF
--- a/docs/AWS.md
+++ b/docs/AWS.md
@@ -1,6 +1,6 @@
 # Amazon Web Services (AWS) Setup Guide
 Amazon Web Services (AWS) provides compute instances that support the
-AMD SEV-SNP and AWS Nitro TEE platforms, but Bearclave only currently supports
+AMD SEV-SNP and AWS Nitro TEE platforms, but Bearclave currently only supports
 AWS Nitro. Follow the steps below to sign up for an AWS account and configure
 the cloud resources required to develop on AWS Nitro Enclaves.
 
@@ -10,11 +10,11 @@ the cloud resources required to develop on AWS Nitro Enclaves.
 1. **Create an [AWS Account](https://aws.amazon.com/)** Note that this will be
    your "root" account and should only be used to setup billing and your user(s).
    I suggest looking for tutorials on AWS IAM Identity Center. Personally, I
-   attached Billing and SystemAdministrator policies to my account. This allows
-   me to login under a "role" with limited permissions instead of as root. Note
-   that your SSO page for logging in under these roles can be found in the
-   "Settings Summary" on your IAM Identity Center page and should look something
-   like `https://<subdomain>.awsapps.com/start`
+   attached Billing and SystemAdministrator policies to my "developer" user.
+   This allows me to login under a "role" with limited permissions instead of 
+   as root. Note that your SSO page for logging in under these roles can be
+   found in the "Settings Summary" on your IAM Identity Center page and should
+   look something like `https://<subdomain>.awsapps.com/start`
 
 2. **Setup Billing** You will need a valid billing method to deploy the
    TEE-enabled EC2 instances.
@@ -55,8 +55,12 @@ stopping, and sshing into your EC2 instances.
 
 ---
 
-### Step 1: Choosing and Launching an EC2 Instance
-Follow these steps to launch a Nitro-enabled EC2 instance from the web console:
+### Configure an EC2 Instance for Nitro Enclave development
+The AWS Nitro developer workflow differs from AMD and Intel on GCP in that we
+build and deploy the enclave program on the EC2 instance (as opposed to doing
+it locally). Follow these steps to launch a Nitro-enabled EC2 instance from the
+web console and install necessary tools for deploying Nitro applications:
+
 1. **Select a Nitro-enabled Instance**
    Visit the [Nitro-enabled instances guide](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#instance-hypervisor-type)
    to select a supported instance type. Make sure the instance has enough vCPUs
@@ -72,40 +76,31 @@ Follow these steps to launch a Nitro-enabled EC2 instance from the web console:
    After launching the instance, note the public IP and add it to your SSH
    configuration for quicker access.
 
-#### Example SSH Configuration
-```bash
-Host ec2-nitro
-    Hostname ec2-3-82-190-249.compute-1.amazonaws.com
-    # AmazonLinux uses "ec2-user" and Ubuntu uses "ubuntu" as login usernames
-    User ec2-user 
-    IdentitiesOnly yes
-    # Tell ssh which key to use when logging into the instance
-    IdentityFile ~/.ssh/ec2-key--tahardi-bearclave.pem
-    # These two will keep your ssh session alive even if you are not
-    # active at your computer. Useful if you are running long tests
-    ServerAliveInterval 300
-    ServerAliveCountMax 2
-```
+   ```bash
+   Host ec2-nitro
+       Hostname ec2-3-82-190-249.compute-1.amazonaws.com
+       # AmazonLinux uses "ec2-user" and Ubuntu uses "ubuntu" as login usernames
+       User ec2-user 
+       IdentitiesOnly yes
+       # Tell ssh which key to use when logging into the instance
+       IdentityFile ~/.ssh/ec2-key--tahardi-bearclave.pem
+       # These two will keep your ssh session alive even if you are not
+       # active at your computer. Useful if you are running long tests
+       ServerAliveInterval 300
+       ServerAliveCountMax 2
+   ```
 
----
-
-### Step 2: Install Required Tools and Libraries
-The AWS Nitro developer workflow differs from AMD and Intel on GCP in that we
-build and deploy the enclave program on the EC2 instance (as opposed to doing
-it locally). Follow these steps to install the necessary tools for building
-and deploying Nitro applications on your EC2 instance.
-
-1. **SSH into your EC2 instance**
+4. **SSH into your EC2 instance**
    ```bash
    ssh ec2-nitro
    ```
 
-2. **Install Git and Nitro CLI**
+5. **Install Git and Nitro CLI**
    ```bash
    sudo dnf install -y git aws-nitro-enclaves-cli aws-nitro-enclaves-cli-devel
    ```
 
-3. **Grant Necessary Permissions**
+6. **Grant Necessary Permissions**
    Add your user to the required groups for Nitro and Docker:
    ```bash
    sudo usermod -aG ne $USER
@@ -113,19 +108,19 @@ and deploying Nitro applications on your EC2 instance.
    ```
    Log out and log back in for these changes to apply.
 
-4. **Enable Nitro Enclaves Allocator Service**
+7. **Enable Nitro Enclaves Allocator Service**
    Enable and start the Nitro Enclaves Allocator Service:
    ```bash
    sudo systemctl enable --now nitro-enclaves-allocator.service
    ```
 
-5. **Enable Docker**
+8. **Enable Docker**
    Start Docker and configure it to run on instance startup:
    ```bash
    sudo systemctl enable --now docker
    ```
 
-6. **Git Configuration for Private Repos (Optional)**
+9. **Git Configuration for Private Repos (Optional)**
    If accessing private GitHub repositories, configure Git:
    ```bash
    git config --global url.https://<YOUR-TOKEN>@github.com/.insteadOf \
@@ -133,101 +128,16 @@ and deploying Nitro applications on your EC2 instance.
    git clone https://github.com/<YOUR-REPO>.git
    ```
 
-7. **Install Go (Optional for Applications)** 
-   ```bash
-   wget https://go.dev/dl/go1.24.3.linux-amd64.tar.gz
-   tar -xvf go1.24.3.linux-amd64.tar.gz
-   sudo mv go /usr/local
-   ```
-   Add Go to your environment variables:
-   ```bash
-   echo 'export GOROOT=/usr/local/go' >> ~/.bash_profile
-   echo 'export GOPATH=$HOME' >> ~/.bash_profile
-   echo 'export PATH=$GOPATH/bin:$GOROOT/bin:$PATH' >> ~/.bash_profile
-   source ~/.bash_profile
-   ```
-
----
-
-### Step 3: Configure AWS Command Line Interface (CLI)
-
-The AWS CLI simplifies EC2 instance management. Use Single Sign-On (SSO) to
-authenticate securely with short-lived credentials.
-
-1. **Install and Configure AWS CLI**
-   Install and set up the CLI using the
-   [AWS CLI guide](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-quickstart.html).
-
-2. **Setup SSO**
-   Run the following command to configure SSO access:
-   ```bash
-   aws configure sso
-   ```
-   Input the following details:
-   - SSO session name: `tahardi-dev-mac`
-   - Start URL: `https://id.awsapps.com/start`
-   - SSO Region: `us-east-2`
-   - SSO Scopes: Default (`sso:account:access`)
-
-3. **Define an AWS CLI Profile**
-   During the setup, specify:
-   - Default region: `us-east-2`
-   - Output format: `json`
-   - Profile name: `tahardi-ec2-mac`
-
-4. **Authenticate with SSO**
-   Sign in using:
-   ```bash
-   aws sso login --profile tahardi-ec2-mac
-   export AWS_PROFILE=tahardi-ec2-mac
-   ```
-
----
-
-### Step 4: Managing Your EC2 Instances
-
-Use these commands to start, describe, or stop your instances via AWS CLI.
-
-1. **Start Instance**
-   ```bash
-   aws ec2 start-instances --instance-ids <INSTANCE-ID>
-   ```
-
-2. **Describe Instance Details**
-   ```bash
-   aws ec2 describe-instances --filters \
-       "Name=tag:Name,Values=<INSTANCE-NAME>" \
-       --query 'Reservations[*].Instances[*].{PublicIp:PublicIpAddress}' \
-       --output json
-   ```
-
-3. **Stop Instance**
-   ```bash
-   aws ec2 stop-instances --instance-ids <INSTANCE-ID>
-   ```
-
-4. **Update Your SSH Configuration Automatically**
-   If the EC2 public IP changes, update your SSH configuration as follows:
-
-   **macOS:**
-   ```bash
-   NEW_IP=$(aws ec2 describe-instances --filters \
-       "Name=tag:Name,Values=<INSTANCE-NAME>" \
-       --query 'Reservations[*].Instances[*].PublicIpAddress' \
-       --output text) && \
-   sed -i '.bak' "s/^.*Hostname.*$/    Hostname ${NEW_IP}/" ~/.ssh/config
-   ```
-
-   **Linux:**
-   ```bash
-   NEW_IP=$(aws ec2 describe-instances --filters \
-       "Name=tag:Name,Values=<INSTANCE-NAME>" \
-       --query 'Reservations[*].Instances[*].PublicIpAddress' \
-       --output text) && \
-   sed -i.bak "s/^.*Hostname.*$/    Hostname ${NEW_IP}/" ~/.ssh/config
-   ```
-
----
-
-With this setup, you're ready to build and deploy applications with AWS Nitro
-Enclaves.
+10. **Install Go (Optional for Applications)** 
+    ```bash
+    wget https://go.dev/dl/go1.24.3.linux-amd64.tar.gz
+    tar -xvf go1.24.3.linux-amd64.tar.gz
+    sudo mv go /usr/local
+    ```
+    Add Go to your environment variables:
+    ```bash
+    echo 'export GOROOT=/usr/local/go' >> ~/.bash_profile
+    echo 'export GOPATH=$HOME' >> ~/.bash_profile
+    echo 'export PATH=$GOPATH/bin:$GOROOT/bin:$PATH' >> ~/.bash_profile
+    source ~/.bash_profile
+    ```

--- a/docs/AWS.md
+++ b/docs/AWS.md
@@ -1,31 +1,60 @@
 # Amazon Web Services (AWS) Setup Guide
 Amazon Web Services (AWS) provides compute instances that support the
 AMD SEV-SNP and AWS Nitro TEE platforms, but Bearclave only currently supports
-AWS Nitro. Follow the steps below to sign up for an AWS account and configure 
+AWS Nitro. Follow the steps below to sign up for an AWS account and configure
 the cloud resources required to develop on AWS Nitro Enclaves.
 
 ---
 
 ### Configure AWS Cloud
-1. **Create an [AWS Account](TODO)** TODO
+1. **Create an [AWS Account](https://aws.amazon.com/)** Note that this will be
+   your "root" account and should only be used to setup billing and your user(s).
+   I suggest looking for tutorials on AWS IAM Identity Center. Personally, I
+   attached Billing and SystemAdministrator policies to my account. This allows
+   me to login under a "role" with limited permissions instead of as root. Note
+   that your SSO page for logging in under these roles can be found in the
+   "Settings Summary" on your IAM Identity Center page and should look something
+   like `https://<subdomain>.awsapps.com/start`
 
-2. **Setup Billing** TODO
+2. **Setup Billing** You will need a valid billing method to deploy the
+   TEE-enabled EC2 instances.
 
 ---
 
 ### Install and Configure the AWS CLI Tool
-TODO
+The Makefile targets in `examples/` require the `aws` cli tool for starting,
+stopping, and sshing into your EC2 instances.
 
-1. **Install the [`aws` CLI](TODO)**
+1. **Install the [`aws` CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)**
 
-2. **Initialize `aws`** TODO
-    ```bash
-    # TODO
-    ```
+2. **Setup SSO** Configure SSO so `aws` can login under your SystemAdministrator
+   role. Again, you can find your SSO login URL on IAM Identity Center under
+   "Settings Summary".
+   ```bash
+   aws configure sso
+   ```
+   Input the following details:
+   - SSO session name: `bearclave`
+   - Start URL: `https://<subdomain>.awsapps.com/start`
+   - SSO Region: `us-east-2`
+   - SSO Scopes: Default (`sso:account:access`)
+
+3. **Define an AWS CLI Profile**
+   During the setup, specify:
+   - Default region: `us-east-2`
+   - Output format: `json`
+   - Profile name: `personal`
+
+4. **Authenticate with SSO**
+   Sign in using:
+   ```bash
+   # personal is the profile named used in `examples/`. If you use a different
+   # profile name you will need to update the Makefile targets to work
+   aws sso login --profile personal
+   ```
 
 ---
 
-TODO: Figure out how to do this all with `aws` cli instead of through console
 ### Step 1: Choosing and Launching an EC2 Instance
 Follow these steps to launch a Nitro-enabled EC2 instance from the web console:
 1. **Select a Nitro-enabled Instance**
@@ -61,16 +90,22 @@ Host ec2-nitro
 ---
 
 ### Step 2: Install Required Tools and Libraries
+The AWS Nitro developer workflow differs from AMD and Intel on GCP in that we
+build and deploy the enclave program on the EC2 instance (as opposed to doing
+it locally). Follow these steps to install the necessary tools for building
+and deploying Nitro applications on your EC2 instance.
 
-After logging into your EC2 instance, execute the following commands to install
-Nitro CLI and other necessary tools.
+1. **SSH into your EC2 instance**
+   ```bash
+   ssh ec2-nitro
+   ```
 
-1. **Install Git and Nitro CLI**
+2. **Install Git and Nitro CLI**
    ```bash
    sudo dnf install -y git aws-nitro-enclaves-cli aws-nitro-enclaves-cli-devel
    ```
 
-2. **Grant Necessary Permissions**
+3. **Grant Necessary Permissions**
    Add your user to the required groups for Nitro and Docker:
    ```bash
    sudo usermod -aG ne $USER
@@ -78,19 +113,19 @@ Nitro CLI and other necessary tools.
    ```
    Log out and log back in for these changes to apply.
 
-3. **Enable Nitro Enclaves Allocator Service**
+4. **Enable Nitro Enclaves Allocator Service**
    Enable and start the Nitro Enclaves Allocator Service:
    ```bash
    sudo systemctl enable --now nitro-enclaves-allocator.service
    ```
 
-4. **Enable Docker**
+5. **Enable Docker**
    Start Docker and configure it to run on instance startup:
    ```bash
    sudo systemctl enable --now docker
    ```
 
-5. **Git Configuration for Private Repos (Optional)**
+6. **Git Configuration for Private Repos (Optional)**
    If accessing private GitHub repositories, configure Git:
    ```bash
    git config --global url.https://<YOUR-TOKEN>@github.com/.insteadOf \
@@ -98,10 +133,10 @@ Nitro CLI and other necessary tools.
    git clone https://github.com/<YOUR-REPO>.git
    ```
 
-6. **Install Go (Optional for Applications)** TODO update go version
+7. **Install Go (Optional for Applications)** 
    ```bash
-   wget https://go.dev/dl/go1.23.3.linux-amd64.tar.gz
-   tar -xvf go1.23.3.linux-amd64.tar.gz
+   wget https://go.dev/dl/go1.24.3.linux-amd64.tar.gz
+   tar -xvf go1.24.3.linux-amd64.tar.gz
    sudo mv go /usr/local
    ```
    Add Go to your environment variables:
@@ -120,7 +155,7 @@ The AWS CLI simplifies EC2 instance management. Use Single Sign-On (SSO) to
 authenticate securely with short-lived credentials.
 
 1. **Install and Configure AWS CLI**
-   Install and set up the CLI using the 
+   Install and set up the CLI using the
    [AWS CLI guide](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-quickstart.html).
 
 2. **Setup SSO**
@@ -195,5 +230,4 @@ Use these commands to start, describe, or stop your instances via AWS CLI.
 ---
 
 With this setup, you're ready to build and deploy applications with AWS Nitro
-Enclaves. Learn more about advanced enclave configuration in the [Nitro
-Enclaves documentation](https://docs.aws.amazon.com/enclaves/latest/user/nitro-enclaves.html).
+Enclaves.

--- a/examples/hello-http-multi/README.md
+++ b/examples/hello-http-multi/README.md
@@ -1,1 +1,137 @@
 # Hello HTTP Multi
+Bearclave adapts to different TEE platforms by requiring two primary programs:
+- **Enclave Servers**: Securely run within the TEE. In this example, two 
+separate HTTP servers ([enclave-server-1](./enclave-server-1/main.go) and 
+[enclave-server-2](./enclave-server-2/main.go)) operate within the TEE
+environment, each configured to handle requests on different routes.
+- **Proxy**: Acts as an HTTP reverse proxy, routing client requests to the
+appropriate enclave server based on the incoming request's route. It uses
+traditional sockets or VSOCK, depending on the platform.
+
+For AWS Nitro Enclaves, which use VSOCK interfaces, the proxy translates HTTP
+requests into VSOCK communication and routes them to the correct enclave server.
+On AMD SEV-SNP and Intel TDX, where networking is directly accessible within the
+TEE, the proxy operates over standard networking.
+
+### Workflow Example
+This example demonstrates an HTTP-based setup with multiple enclave servers:
+1. A **remote client** ("nonclave") sends an HTTP request to the proxy with a
+route (`/v1` or `/v2`) in the URL and user data.
+2. The **proxy** determines the appropriate enclave server to forward the
+request to based on the specified route:
+    - `/v1` -> **enclave-server-1**
+    - `/v2` -> **enclave-server-2**
+
+3. The **selected enclave server** processes the incoming HTTP request,
+generates an attestation report, and includes it in the HTTP response.
+4. The **proxy** relays the server's response back to the client.
+5. The **nonclave** verifies the attestation report and extracts the attested
+data.
+
+### Key Points
+- Each enclave server supports a specific route and processes requests
+independently, enabling a multi-server enclave setup.
+- The proxy transparently handles incoming requests and uses route-based
+forwarding, simplifying TEE application design with multiple enclaves.
+- The solution works across AWS Nitro, AMD SEV-SNP, and Intel TDX by managing
+platform-specific differences within the proxy.
+
+## Run the example locally
+Bearclave supports a "No TEE" mode (`notee`) for running code locally. This
+allows for quick iteration and saves on Cloud infrastructure costs. Assuming
+you have installed the minimum set of dependencies listed in the
+[top-level README](../../README.md), you can run this example locally with:
+
+```bash
+make
+
+# You should see output similar to:
+[enclave-proxy  ] time=2025-07-20T11:51:37.096-04:00 level=INFO msg="loaded config" configs/enclave/notee.yaml="&{Platform:notee Measurement: IPCs:map[] Servers:map[enclave-server-1:{CID:4 Port:8082 Route:/v1} enclave-server-2:{CID:5 Port:8083 Route:/v2}] Proxy:{Port:8080}}"
+[enclave-proxy  ] time=2025-07-20T11:51:37.096-04:00 level=INFO msg="Proxy server started" addr=0.0.0.0:8080
+[enclave-server-1       ] time=2025-07-20T11:51:37.136-04:00 level=INFO msg="loaded config" configs/enclave/notee.yaml="&{Platform:notee Measurement: IPCs:map[] Servers:map[enclave-server-1:{CID:4 Port:8082 Route:/v1} enclave-server-2:{CID:5 Port:8083 Route:/v2}] Proxy:{Port:8080}}"
+[enclave-server-1       ] time=2025-07-20T11:51:37.136-04:00 level=INFO msg="Enclave server 1 started" addr=127.0.0.1:8082
+[enclave-server-2       ] time=2025-07-20T11:51:37.149-04:00 level=INFO msg="loaded config" configs/enclave/notee.yaml="&{Platform:notee Measurement: IPCs:map[] Servers:map[enclave-server-1:{CID:4 Port:8082 Route:/v1} enclave-server-2:{CID:5 Port:8083 Route:/v2}] Proxy:{Port:8080}}"
+[enclave-server-2       ] time=2025-07-20T11:51:37.149-04:00 level=INFO msg="Enclave server 2 started" addr=127.0.0.1:8083
+[nonclave       ] time=2025-07-20T11:51:37.496-04:00 level=INFO msg="loaded config" configs/nonclave/notee.yaml="&{Platform:notee Measurement:Not a TEE platform. Code measurements are not real. IPCs:map[] Servers:map[enclave-server-1:{CID:0 Port:0 Route:/v1} enclave-server-2:{CID:0 Port:0 Route:/v2}] Proxy:{Port:8080}}"
+[nonclave       ] time=2025-07-20T11:51:37.496-04:00 level=INFO msg="sending request to url" url=http://127.0.0.1:8080/v2
+[enclave-server-2       ] time=2025-07-20T11:51:37.497-04:00 level=INFO msg="attesting userdata" userdata="Hello from enclave-server-2!"
+[nonclave       ] time=2025-07-20T11:51:37.498-04:00 level=INFO msg="verified userdata" userdata="Hello from enclave-server-2!"
+[nonclave       ] time=2025-07-20T11:51:37.498-04:00 level=INFO msg="sending request to url" url=http://127.0.0.1:8080/v1
+[enclave-server-1       ] time=2025-07-20T11:51:37.498-04:00 level=INFO msg="attesting userdata" userdata="Hello from enclave-server-1!"
+[nonclave       ] time=2025-07-20T11:51:37.499-04:00 level=INFO msg="verified userdata" userdata="Hello from enclave-server-1!"
+```
+
+## Run the example on AWS Nitro
+Recall that AWS Nitro Enclave development requires building and deploying
+from the EC2 instance itself. Assuming you have configured your AWS account
+and the necessary cloud resources laid out in the
+[AWS setup guide](../../docs/AWS.md), you can run the example with:
+
+1. Login to the AWS cli
+    ```bash
+    make aws-cli-login 
+    ```
+2. Start your EC2 instance
+    ```bash
+    make aws-nitro-instance-start
+   ```
+3. Log into your EC2 instance
+    ```bash
+   make aws-nitro-instance-ssh 
+   ```
+4. Clone (if needed) bearclave and cd to example
+    ```bash
+   git clone git@github.com:tahardi/bearclave.git
+   cd bearclave/examples/hello-http-multi
+   ```
+5. Build and run the enclave program
+    ```bash
+    make aws-nitro-enclave-run-eif
+    
+    # This will attach a debug console to the enclave program so you can see
+    # its log. Note that this will change the code measurement, however, to
+    # indicate the enclave is in debug mode (and thus may leak sensitive info)
+    make aws-nitro-enclave-run-eif-debug
+    ```
+6. Run the proxy program
+    ```bash
+   make aws-nitro-proxy-run 
+   ```
+7. In a separate terminal window, run the nonclave program. Remember this is a
+   remote client making an HTTP request so you can run it from your local machine
+    ```bash
+    make aws-nitro-nonclave-run
+    ```
+8. Remember to turn off your EC2 instance when you are finished. Otherwise, you
+   will continue to incur AWS cloud charges.
+    ```bash
+    make aws-nitro-instance-stop 
+    ```
+
+## Run the example on GCP AMD SEV-SNP or Intel TDX
+Unlike AWS Nitro, the GCP AMD and Intel programs are built and deployed from
+your local machine. Assuming you have configured your GCP account and the
+necessary cloud resources laid out in the [GCP setup guide](../../docs/GCP.md),
+you can run the example with:
+
+1. Start your Compute instance. Note that these steps demonstrate running the
+   example on AMD SEV-SNP, but you can simply replace `sev` with `tdx` in the make
+   commands as the process is exactly the same.
+    ```bash
+    make gcp-sev-instance-start
+   ```
+2. Build and deploy the enclave and proxy programs. Note that unlike AWS Nitro,
+   the enclave and proxy are bundled together and both deployed within the TEE
+   when run on SEV or TDX.
+    ```bash
+    make gcp-sev-enclave-run-image
+    ```
+3. Run the nonclave program
+    ```bash
+   make gcp-sev-nonclave-run
+   ```
+4. Remember to turn off your Compute instance when you are finished. Otherwise,
+   you will continue to incur GCP cloud charges.
+    ```bash
+    make gcp-sev-instance-stop 
+    ```

--- a/examples/hello-http/README.md
+++ b/examples/hello-http/README.md
@@ -1,1 +1,126 @@
 # Hello HTTP
+Bearclave adapts to different TEE platforms by requiring two programs:
+- **Enclave**: Runs securely within the TEE and now functions as a standard 
+HTTP server.
+- **Proxy**: Acts as an HTTP reverse proxy, bridging communication between
+the client and the enclave. It forwards requests using traditional sockets or
+VSOCK, depending on the platform.
+
+For AWS Nitro Enclaves, which rely on VSOCK interfaces, the proxy translates
+client HTTP requests into VSOCK communication and routes them to the enclave.
+On AMD SEV-SNP and Intel TDX, where the networking stack is directly accessible
+within the TEE, the proxy still runs but operates over standard networking.
+
+### Workflow Example
+This example showcases an HTTP-based attestation flow:
+1. A **remote client** ("nonclave") sends an HTTP request to the proxy with
+user data for attestation.
+2. The **proxy** forwards the request to the enclave via a traditional socket
+or VSOCK, depending on the platform.
+3. The **enclave**, now an HTTP server, processes the HTTP request, generates
+an attestation report, and sends it back as an HTTP response.
+4. The **proxy** relays the response back to the remote client.
+5. The **nonclave** verifies the attestation report and extracts the attested
+data.
+
+### Key Points
+- The enclave operates as a complete HTTP server, allowing developers to
+use standard HTTP-based applications without significant changes to leverage
+TEE environments.
+- The proxy transparently handles platform-specific differences, simplifying
+deployment across AWS Nitro, AMD SEV-SNP, and Intel TDX.
+
+
+## Run the example locally
+Bearclave supports a "No TEE" mode (`notee`) for running code locally. This
+allows for quick iteration and saves on Cloud infrastructure costs. Assuming
+you have installed the minimum set of dependencies listed in the
+[top-level README](../../README.md), you can run this example locally with:
+
+```bash
+make
+
+# You should see output similar to:
+[enclave-proxy  ] time=2025-07-20T11:41:34.789-04:00 level=INFO msg="loaded config" configs/enclave/notee.yaml="&{Platform:notee Measurement: IPCs:map[] Servers:map[enclave-server:{CID:4 Port:8082 Route:}] Proxy:{Port:8080}}"
+[enclave-proxy  ] time=2025-07-20T11:41:34.789-04:00 level=INFO msg="Proxy server started" addr=0.0.0.0:8080
+[enclave        ] time=2025-07-20T11:41:34.793-04:00 level=INFO msg="loaded config" configs/enclave/notee.yaml="&{Platform:notee Measurement: IPCs:map[] Servers:map[enclave-server:{CID:4 Port:8082 Route:}] Proxy:{Port:8080}}"
+[enclave        ] time=2025-07-20T11:41:34.793-04:00 level=INFO msg="Enclave server started" addr=127.0.0.1:8082
+[nonclave       ] time=2025-07-20T11:41:35.131-04:00 level=INFO msg="loaded config" configs/nonclave/notee.yaml="&{Platform:notee Measurement:Not a TEE platform. Code measurements are not real. IPCs:map[] Servers:map[] Proxy:{Port:8080}}"
+[enclave        ] time=2025-07-20T11:41:35.132-04:00 level=INFO msg="attesting userdata" userdata="Hello, world!"
+[nonclave       ] time=2025-07-20T11:41:35.133-04:00 level=INFO msg="verified userdata" userdata="Hello, world!"
+```
+
+## Run the example on AWS Nitro
+Recall that AWS Nitro Enclave development requires building and deploying
+from the EC2 instance itself. Assuming you have configured your AWS account
+and the necessary cloud resources laid out in the
+[AWS setup guide](../../docs/AWS.md), you can run the example with:
+
+1. Login to the AWS cli
+    ```bash
+    make aws-cli-login 
+    ```
+2. Start your EC2 instance
+    ```bash
+    make aws-nitro-instance-start
+   ```
+3. Log into your EC2 instance
+    ```bash
+   make aws-nitro-instance-ssh 
+   ```
+4. Clone (if needed) bearclave and cd to example
+    ```bash
+   git clone git@github.com:tahardi/bearclave.git
+   cd bearclave/examples/hello-http
+   ```
+5. Build and run the enclave program
+    ```bash
+    make aws-nitro-enclave-run-eif
+    
+    # This will attach a debug console to the enclave program so you can see
+    # its log. Note that this will change the code measurement, however, to
+    # indicate the enclave is in debug mode (and thus may leak sensitive info)
+    make aws-nitro-enclave-run-eif-debug
+    ```
+6. Run the proxy program
+    ```bash
+   make aws-nitro-proxy-run 
+   ```
+7. In a separate terminal window, run the nonclave program. Remember this is a
+   remote client making an HTTP request so you can run it from your local machine
+    ```bash
+    make aws-nitro-nonclave-run
+    ```
+8. Remember to turn off your EC2 instance when you are finished. Otherwise, you
+   will continue to incur AWS cloud charges.
+    ```bash
+    make aws-nitro-instance-stop 
+    ```
+
+## Run the example on GCP AMD SEV-SNP or Intel TDX
+Unlike AWS Nitro, the GCP AMD and Intel programs are built and deployed from
+your local machine. Assuming you have configured your GCP account and the
+necessary cloud resources laid out in the [GCP setup guide](../../docs/GCP.md),
+you can run the example with:
+
+1. Start your Compute instance. Note that these steps demonstrate running the
+   example on AMD SEV-SNP, but you can simply replace `sev` with `tdx` in the make
+   commands as the process is exactly the same.
+    ```bash
+    make gcp-sev-instance-start
+   ```
+2. Build and deploy the enclave and proxy programs. Note that unlike AWS Nitro,
+   the enclave and proxy are bundled together and both deployed within the TEE
+   when run on SEV or TDX.
+    ```bash
+    make gcp-sev-enclave-run-image
+    ```
+3. Run the nonclave program
+    ```bash
+   make gcp-sev-nonclave-run
+   ```
+4. Remember to turn off your Compute instance when you are finished. Otherwise,
+   you will continue to incur GCP cloud charges.
+    ```bash
+    make gcp-sev-instance-stop 
+    ```

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -124,7 +124,7 @@ when run on SEV or TDX.
     ```bash
    make gcp-sev-nonclave-run
    ```
-5. Remember to turn off your Compute instance when you are finished. Otherwise,
+4. Remember to turn off your Compute instance when you are finished. Otherwise,
 you will continue to incur GCP cloud charges.
     ```bash
     make gcp-sev-instance-stop 

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -1,1 +1,131 @@
 # Hello World
+Bearclave supports multiple TEE platforms, which influences application design.
+Specifically, two programs are required:
+- **Enclave**: The code running securely within the TEE.
+- **Proxy**: A bridging program for communication between the enclave and 
+external clients.
+
+For AWS Nitro Enclaves, this architecture is necessary because enclaves use
+VSOCK (virtual socket) interfaces, requiring a proxy to handle traditional
+socket-based communications (e.g., HTTP) with external clients. This proxy
+forwards data through a VSOCK to the enclave. In contrast, AMD SEV-SNP and
+Intel TDX allow enclaves direct access to the networking stack, so the proxy
+can run inside the TEE, making it less essential but still included for
+consistency.
+
+### Workflow Example
+This example demonstrates a simple attestation flow:
+1. A **remote client** ("nonclave") sends an HTTP request for enclave
+attestation over some data.
+2. The **proxy** receives the HTTP request, unwraps the data, and forwards it
+via a VSOCK to the enclave.
+3. The **enclave** processes the data, generates an attestation, and sends the
+report back to the proxy via the VSOCK.
+4. The **proxy** wraps the attestation into an HTTP response and returns it to
+the client.
+5. The **nonclave** verifies the attestation and extracts the attested data.
+
+Key points:
+- The enclave communicates using a minimalist protocol: listening for a byte
+stream via VSOCK and assuming it's user data.
+- For simplicity, the enclave could be designed as a standard HTTP server
+(demonstrated in the [hello-http](../hello-http/README.md) example),
+avoiding the need for developers to rewrite applications for the TEE.
+
+## Run the example locally
+Bearclave supports a "No TEE" mode (`notee`) for running code locally. This
+allows for quick iteration and saves on Cloud infrastructure costs. Assuming
+you have installed the minimum set of dependencies listed in the
+[top-level README](../../README.md), you can run this example locally with:
+
+```bash
+make
+
+# You should see output similar to:
+[enclave        ] time=2025-07-20T10:25:04.534-04:00 level=INFO msg="loaded config" configs/enclave/notee.yaml="&{Platform:notee Measurement: IPCs:map[enclave:{Endpoint:127.0.0.1:8083} enclave-proxy:{Endpoint:127.0.0.1:8082}] Servers:map[] Proxy:{Port:8080}}"
+[enclave        ] time=2025-07-20T10:25:04.534-04:00 level=INFO msg="waiting to receive userdata from enclave-proxy..."
+[enclave-proxy  ] time=2025-07-20T10:25:04.564-04:00 level=INFO msg="loaded config" configs/enclave/notee.yaml="&{Platform:notee Measurement: IPCs:map[enclave:{Endpoint:127.0.0.1:8083} enclave-proxy:{Endpoint:127.0.0.1:8082}] Servers:map[] Proxy:{Port:8080}}"
+[enclave-proxy  ] time=2025-07-20T10:25:04.564-04:00 level=INFO msg="HTTP server started" addr=0.0.0.0:8080
+[nonclave       ] time=2025-07-20T10:25:04.904-04:00 level=INFO msg="loaded config" configs/nonclave/notee.yaml="&{Platform:notee Measurement:Not a TEE platform. Code measurements are not real. IPCs:map[] Servers:map[] Proxy:{Port:8080}}"
+[enclave-proxy  ] time=2025-07-20T10:25:04.904-04:00 level=INFO msg="sending userdata to enclave..." userdata="Hello, world!"
+[enclave-proxy  ] time=2025-07-20T10:25:04.904-04:00 level=INFO msg="waiting for attestation from enclave..."
+[enclave        ] time=2025-07-20T10:25:04.904-04:00 level=INFO msg="attesting userdata" userdata="Hello, world!"
+[enclave        ] time=2025-07-20T10:25:04.904-04:00 level=INFO msg="sending attestation to enclave-proxy..."
+[enclave        ] time=2025-07-20T10:25:04.905-04:00 level=INFO msg="waiting to receive userdata from enclave-proxy..."
+[nonclave       ] time=2025-07-20T10:25:04.905-04:00 level=INFO msg="verified userdata" userdata="Hello, world!"
+```
+
+## Run the example on AWS Nitro
+Recall that AWS Nitro Enclave development requires building and deploying
+from the EC2 instance itself. Assuming you have configured your AWS account
+and the necessary cloud resources laid out in the
+[AWS setup guide](../../docs/AWS.md), you can run the example with:
+
+1. Login to the AWS cli
+    ```bash
+    make aws-cli-login 
+    ```
+2. Start your EC2 instance
+    ```bash
+    make aws-nitro-instance-start
+   ```
+3. Log into your EC2 instance
+    ```bash
+   make aws-nitro-instance-ssh 
+   ```
+4. Clone (if needed) bearclave and cd to example
+    ```bash
+   git clone git@github.com:tahardi/bearclave.git
+   cd bearclave/examples/hello-world
+   ```
+5. Build and run the enclave program
+    ```bash
+    make aws-nitro-enclave-run-eif
+    
+    # This will attach a debug console to the enclave program so you can see
+    # its log. Note that this will change the code measurement, however, to
+    # indicate the enclave is in debug mode (and thus may leak sensitive info)
+    make aws-nitro-enclave-run-eif-debug
+    ```
+6. Run the proxy program
+    ```bash
+   make aws-nitro-proxy-run 
+   ```
+7. In a separate terminal window, run the nonclave program. Remember this is a
+remote client making an HTTP request so you can run it from your local machine
+    ```bash
+    make aws-nitro-nonclave-run
+    ```
+8. Remember to turn off your EC2 instance when you are finished. Otherwise, you
+will continue to incur AWS cloud charges.
+    ```bash
+    make aws-nitro-instance-stop 
+    ```
+   
+## Run the example on GCP AMD SEV-SNP or Intel TDX
+Unlike AWS Nitro, the GCP AMD and Intel programs are built and deployed from
+your local machine. Assuming you have configured your GCP account and the
+necessary cloud resources laid out in the [GCP setup guide](../../docs/GCP.md), 
+you can run the example with:
+
+1. Start your Compute instance. Note that these steps demonstrate running the
+example on AMD SEV-SNP, but you can simply replace `sev` with `tdx` in the make
+commands as the process is exactly the same.
+    ```bash
+    make gcp-sev-instance-start
+   ```
+2. Build and deploy the enclave and proxy programs. Note that unlike AWS Nitro,
+the enclave and proxy are bundled together and both deployed within the TEE
+when run on SEV or TDX.
+    ```bash
+    make gcp-sev-enclave-run-image
+    ```
+3. Run the nonclave program
+    ```bash
+   make gcp-sev-nonclave-run
+   ```
+5. Remember to turn off your Compute instance when you are finished. Otherwise,
+you will continue to incur GCP cloud charges.
+    ```bash
+    make gcp-sev-instance-stop 
+    ```


### PR DESCRIPTION
Add basic AWS setup instructions and readmes for each examples. Still a fair amount of information missing, but should be enough to serve as a good starting point. I plan to get a friend or two to run through the setup and examples so that I can refine the documentation.