### PR TITLE
[TAH-5] On schedule workflow

### DIFF
--- a/.github/workflows/on-schedule.yml
+++ b/.github/workflows/on-schedule.yml
@@ -3,7 +3,7 @@ name: On Schedule
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * 0'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/on-schedule.yml
+++ b/.github/workflows/on-schedule.yml
@@ -1,0 +1,36 @@
+name: On Schedule
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  notee-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        example: [hello-world, hello-http, hello-http-multi]
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: './go.mod'
+
+      - name: Install Process Compose
+        run: |
+          sh -c "$(curl --location https://raw.githubusercontent.com/F1bonacc1/process-compose/main/scripts/get-pc.sh)" -- -d -b /usr/local/bin
+
+      - name: Run Notee Example - ${{ matrix.example }}
+        working-directory: examples/${{ matrix.example }}
+        run: make
+


### PR DESCRIPTION
Add a simple schedule workflow (runs once a week) to run the example applications in "no TEE" mode. Eventually, once I've better figured out automated deployments, this will run tests against actual TEE platforms (e.g., Nitro, AMD, Intel)