### PR TITLE
Bump golangci-lint so it works with new go version

### DIFF
--- a/.github/workflows/on-schedule.yml
+++ b/.github/workflows/on-schedule.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.7.1
+          version: v2.10.1
           args: --timeout=3m --config=./.golangci.yaml
 
   unit-test:


### PR DESCRIPTION
## Describe your changes
Updated the on-pr in the previous PR but forgot to do on-schedule as well.

## Related Jira cards

## Pre-Merge Checklist
If any of these checks are missing, please provide an explanation.

- [x] I have updated README files, if applicable.
- [x] I have updated workflows, if applicable.
- [x] Dependencies in `go.mod` only reference tagged or `main` branch commits
- [x] I have run `make pre-pr` and all checks have passed.
- [x] I have run platform-specific integration tests, if applicable.
